### PR TITLE
Fixed known EPF bug

### DIFF
--- a/Capricorn/Drawing/DAGraphics.cs
+++ b/Capricorn/Drawing/DAGraphics.cs
@@ -4,16 +4,6 @@ using System.Drawing.Imaging;
 
 namespace Capricorn.Drawing
 {
-    public enum ImageType
-    {
-        EPF,
-        MPF,
-        HPF,
-        SPF,
-        EFA,
-        ZP,
-        Tile
-    }
 
     public class DAGraphics
     {
@@ -28,22 +18,22 @@ namespace Capricorn.Drawing
 
         public unsafe static Bitmap RenderImage(HPFImage hpf, Palette256 palette)
         {
-            return SimpleRender(hpf.Width, hpf.Height, hpf.RawData, palette, ImageType.HPF);
+            return SimpleRender(hpf.Width, hpf.Height, hpf.RawData, palette);
         }
         public unsafe static Bitmap RenderImage(EPFFrame epf, Palette256 palette)
         {
-            return SimpleRender(epf.Width, epf.Height, epf.RawData, palette, ImageType.EPF);
+            return SimpleRender(epf.Width, epf.Height, epf.RawData, palette);
         }
         public unsafe static Bitmap RenderImage(MPFFrame mpf, Palette256 palette)
         {
-            return SimpleRender(mpf.Width, mpf.Height, mpf.RawData, palette, ImageType.MPF);
+            return SimpleRender(mpf.Width, mpf.Height, mpf.RawData, palette);
         }
         public unsafe static Bitmap RenderTile(byte[] tileData, Palette256 palette)
         {
-            return SimpleRender(Tileset.TileWidth, Tileset.TileHeight, tileData, palette, ImageType.Tile);
+            return SimpleRender(Tileset.TileWidth, Tileset.TileHeight, tileData, palette);
         }
 
-        private unsafe static Bitmap SimpleRender(int width, int height, byte[] data, Palette256 palette, ImageType type)
+        private unsafe static Bitmap SimpleRender(int width, int height, byte[] data, Palette256 palette)
         {
             Bitmap image = new Bitmap(width, height);
 
@@ -55,16 +45,8 @@ namespace Capricorn.Drawing
 
                 for (int x = 0; x < bmd.Width; x++)
                 {
-                    int colorIndex = 0;
-                    if (type == ImageType.EPF)
-                    {
-                        colorIndex = data[x * height + y];
-                    }
-                    else
-                    {
-                        colorIndex = data[y * width + x];
-                    }
-
+                    int colorIndex = colorIndex = data[y * width + x];
+                    
                     if (colorIndex == 0) continue;
 
                     #region 32 Bit Render
@@ -114,12 +96,6 @@ namespace Capricorn.Drawing
 
             // Unlock Bits
             image.UnlockBits(bmd);
-
-            // Flip Image
-            if (type == ImageType.EPF)
-            {
-                image.RotateFlip(RotateFlipType.Rotate90FlipX);
-            }
 
             // Return Bitmap
             return image;

--- a/Capricorn/Drawing/EPF.cs
+++ b/Capricorn/Drawing/EPF.cs
@@ -171,8 +171,8 @@ namespace Capricorn.Drawing
                 reader.BaseStream.Seek(epf.tocAddress + i * 16, SeekOrigin.Begin);
 
                 #region Get Frame Header
-                int left = reader.ReadUInt16();
                 int top = reader.ReadUInt16();
+                int left = reader.ReadUInt16();
                 int right = reader.ReadUInt16();
                 int bottom = reader.ReadUInt16();
 


### PR DESCRIPTION
Top and Left were read out of order. This was causing the EPF image to render rotated. I fixed this for my own local rewrite of Capricorn.

I didn't compile and test though for this project, it should be fine though. Revert if it doesnt work?